### PR TITLE
Updates for 1/2018 Vue Module Versions

### DIFF
--- a/build/webpack.client.config.js
+++ b/build/webpack.client.config.js
@@ -3,6 +3,7 @@ const merge = require('webpack-merge')
 const base = require('./webpack.base.config')
 const HTMLPlugin = require('html-webpack-plugin')
 const SWPrecachePlugin = require('sw-precache-webpack-plugin')
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 
 const config = merge(base, {
   resolve: {
@@ -23,18 +24,14 @@ const config = merge(base, {
     // generate output HTML
     new HTMLPlugin({
       template: 'src/index.template.html'
-    })
+    }),
   ]
 })
 
 if (process.env.NODE_ENV === 'production') {
   config.plugins.push(
     // minify JS
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false
-      }
-    }),
+    new UglifyJsPlugin(),
     // auto generate service worker
     new SWPrecachePlugin({
       cacheId: 'vue-hn',

--- a/package.json
+++ b/package.json
@@ -28,12 +28,7 @@
     "firebase": "^3.7.2",
     "lru-cache": "^4.0.2",
     "serve-favicon": "^2.4.1",
-    "vue-router": "^2.3.0",
-    "vue-server-renderer": "^2.2.6",
-    "vue-style-loader": "^2.0.4",
-    "vuex": "^2.2.1",
-    "vuex-router-sync": "^4.1.2",
-    "webpack-merge": "^4.0.0"
+    "vuex-router-sync": "^5.0.0"
   },
   "devDependencies": {
     "@types/vue-router": "^2.0.0",
@@ -48,14 +43,21 @@
     "sw-precache-webpack-plugin": "^0.9.1",
     "ts-loader": "^2.0.3",
     "typescript": "^2.2.2",
+    "uglifyjs-webpack-plugin": "^1.1.6",
     "url-loader": "^0.5.8",
-    "vue": "^2.2.6",
-    "vue-class-component": "^5.0.1",
-    "vue-loader": "^11.1.4",
-    "vue-ssr-webpack-plugin": "^1.0.2",
-    "vue-template-compiler": "^2.2.6",
+    "vue": "^2.5.13",
+    "vue-class-component": "^6.1.2",
+    "vue-loader": "^13.7.0",
+    "vue-router": "^3.0.1",
+    "vue-router-sync": "^0.1.0",
+    "vue-ssr-webpack-plugin": "^3.0.0",
+    "vue-style-loader": "^3.0.3",
+    "vue-template-compiler": "^2.5.13",
+    "vue-ts-locale": "^1.0.2",
+    "vuex": "^3.0.1",
     "webpack": "^2.2.1",
     "webpack-dev-middleware": "^1.10.1",
-    "webpack-hot-middleware": "^2.17.1"
+    "webpack-hot-middleware": "^2.17.1",
+    "webpack-merge": "^4.0.0"
   }
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,7 +1,6 @@
 declare module '*.vue' {
   import Vue from 'vue'
-  let ComponentOptions: Vue.ComponentOptions<any>;
-  export default ComponentOptions;
+  export default Vue;
 }
 
 declare var require: {


### PR DESCRIPTION
* package json updated with latest vue related module versions. 
* global.d.ts removed ComponentOptions, directly exporting Vue (was throwing errors); 
* webpack.client.config: updated to use standalone uglifyjs-webpack